### PR TITLE
fix(credentials)!: set access key id as the ses smtp username

### DIFF
--- a/src/provider/credentials-handler.lambda.ts
+++ b/src/provider/credentials-handler.lambda.ts
@@ -36,7 +36,7 @@ export async function handler(event: OnEventRequest): Promise<OnEventResponse | 
       .putSecretValue({
         SecretId: secretId,
         SecretString: JSON.stringify({
-          [Credentials.USERNAME]: username,
+          [Credentials.USERNAME]: accessKeyId,
           [Credentials.PASSWORD]: smtpPassword,
         }),
       })

--- a/test/__snapshots__/integ.default.test.ts.snap
+++ b/test/__snapshots__/integ.default.test.ts.snap
@@ -43,7 +43,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4ca6cc8bad52f8d98ac489ed69742d6509d190e0ee94a7ef6bd93ab724ac8167.zip",
+          "S3Key": "02fcc5b1d34422cbd3a65c36de7fea0cb6b9bbcec2273f210081693966156314.zip",
         },
         "Description": "src/provider/credentials-handler.lambda.ts",
         "Handler": "index.handler",

--- a/test/provider/credentials-handler-function.test.ts
+++ b/test/provider/credentials-handler-function.test.ts
@@ -1,6 +1,7 @@
 import { OnEventHandler, OnEventRequest } from "aws-cdk-lib/custom-resources/lib/provider-framework/types";
 import * as SDK from "aws-sdk";
 import * as AWS from "aws-sdk-mock";
+import { PutSecretValueRequest } from "aws-sdk/clients/secretsmanager";
 import * as sinon from "sinon";
 
 describe("provider.credentials-handler.lambda", () => {
@@ -65,5 +66,15 @@ describe("provider.credentials-handler.lambda", () => {
     expect(response?.PhysicalResourceId).toEqual("access-key-id-1234");
     sinon.assert.calledOnce(createAccessKeyFake);
     sinon.assert.calledOnce(putSecretValueFake);
+    sinon.assert.calledOnceWithMatch(
+      putSecretValueFake,
+      sinon.match.has("SecretString").and(
+        sinon.match((value: PutSecretValueRequest) => {
+          const secretString = JSON.parse(value.SecretString as string);
+
+          return secretString.username == "access-key-id-1234";
+        })
+      )
+    );
   });
 });


### PR DESCRIPTION
Fixes https://github.com/pepperize/cdk-ses-smtp-credentials/issues/219