### PR TITLE
feat: allow custom key names for AWS SES SMTP credentials in Secrets Manager

### DIFF
--- a/API.md
+++ b/API.md
@@ -276,9 +276,23 @@ const sesSmtpCredentialsProps: SesSmtpCredentialsProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#@pepperize/cdk-ses-smtp-credentials.SesSmtpCredentialsProps.property.passwordSecretKey">passwordSecretKey</a></code> | <code>string</code> | Optional, the key name to use in the secret to write the password to (defaults to Credentials.PASSWORD). |
 | <code><a href="#@pepperize/cdk-ses-smtp-credentials.SesSmtpCredentialsProps.property.secret">secret</a></code> | <code>aws-cdk-lib.aws_secretsmanager.ISecret</code> | Optional, an SecretsManager secret to write the AWS SES Smtp credentials to. |
 | <code><a href="#@pepperize/cdk-ses-smtp-credentials.SesSmtpCredentialsProps.property.user">user</a></code> | <code>aws-cdk-lib.aws_iam.IUser</code> | The user for which to create an AWS Access Key and to generate the smtp password. |
 | <code><a href="#@pepperize/cdk-ses-smtp-credentials.SesSmtpCredentialsProps.property.userName">userName</a></code> | <code>string</code> | Optional, a username to create a new user if no existing user is given. |
+| <code><a href="#@pepperize/cdk-ses-smtp-credentials.SesSmtpCredentialsProps.property.userNameSecretKey">userNameSecretKey</a></code> | <code>string</code> | Optional, the key name to use in the secret to write the username to (defaults to Credentials.USERNAME). |
+
+---
+
+##### `passwordSecretKey`<sup>Optional</sup> <a name="passwordSecretKey" id="@pepperize/cdk-ses-smtp-credentials.SesSmtpCredentialsProps.property.passwordSecretKey"></a>
+
+```typescript
+public readonly passwordSecretKey: string;
+```
+
+- *Type:* string
+
+Optional, the key name to use in the secret to write the password to (defaults to Credentials.PASSWORD).
 
 ---
 
@@ -317,6 +331,18 @@ public readonly userName: string;
 - *Type:* string
 
 Optional, a username to create a new user if no existing user is given.
+
+---
+
+##### `userNameSecretKey`<sup>Optional</sup> <a name="userNameSecretKey" id="@pepperize/cdk-ses-smtp-credentials.SesSmtpCredentialsProps.property.userNameSecretKey"></a>
+
+```typescript
+public readonly userNameSecretKey: string;
+```
+
+- *Type:* string
+
+Optional, the key name to use in the secret to write the username to (defaults to Credentials.USERNAME).
 
 ---
 

--- a/src/provider/credentials-handler.lambda.ts
+++ b/src/provider/credentials-handler.lambda.ts
@@ -16,6 +16,8 @@ export async function handler(event: OnEventRequest): Promise<OnEventResponse | 
     // Create access key
     const username = event.ResourceProperties.UserName;
     const secretId = event.ResourceProperties.SecretId;
+    const userNameSecretKey = event.ResourceProperties.UserNameSecretKey;
+    const passwordSecretKey = event.ResourceProperties.PasswordSecretKey;
     const region = process.env.AWS_DEFAULT_REGION as string;
     const iam = new AWS.IAM();
     const secretsManager = new AWS.SecretsManager();
@@ -36,8 +38,8 @@ export async function handler(event: OnEventRequest): Promise<OnEventResponse | 
       .putSecretValue({
         SecretId: secretId,
         SecretString: JSON.stringify({
-          [Credentials.USERNAME]: accessKeyId,
-          [Credentials.PASSWORD]: smtpPassword,
+          [userNameSecretKey || Credentials.USERNAME]: accessKeyId,
+          [passwordSecretKey || Credentials.PASSWORD]: smtpPassword,
         }),
       })
       .promise();

--- a/src/ses-smtp-credentials.ts
+++ b/src/ses-smtp-credentials.ts
@@ -18,6 +18,14 @@ export interface SesSmtpCredentialsProps {
    * Optional, an SecretsManager secret to write the AWS SES Smtp credentials to.
    */
   readonly secret?: secretsmanager.ISecret;
+  /**
+   * Optional, the key name to use in the secret to write the username to (defaults to Credentials.USERNAME)
+   */
+  readonly userNameSecretKey?: string;
+  /**
+   * Optional, the key name to use in the secret to write the password to (defaults to Credentials.PASSWORD)
+   */
+  readonly passwordSecretKey?: string;
 }
 
 /**
@@ -93,6 +101,8 @@ export class SesSmtpCredentials extends Construct {
       properties: {
         UserName: user.userName,
         SecretId: this.secret.secretArn,
+        UserNameSecretKey: props.userNameSecretKey,
+        PasswordSecretKey: props.passwordSecretKey,
       },
     } as CustomResourceProps);
     customResource.node.addDependency(user);

--- a/test/__snapshots__/integ.default.test.ts.snap
+++ b/test/__snapshots__/integ.default.test.ts.snap
@@ -167,7 +167,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "350dbe76f30257cb7713305422a5ab53d08b5e104e10b60d51a5ead5a69ed7b2.zip",
+          "S3Key": "4b0311836178e83d88a02c0c8b057979a3b8444fc19ceb3803bed1d5014a5266.zip",
         },
         "Description": "src/provider/credentials-handler.lambda.ts",
         "Environment": Object {

--- a/test/provider/__snapshots__/credentials-provider.test.ts.snap
+++ b/test/provider/__snapshots__/credentials-provider.test.ts.snap
@@ -109,7 +109,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "350dbe76f30257cb7713305422a5ab53d08b5e104e10b60d51a5ead5a69ed7b2.zip",
+          "S3Key": "4b0311836178e83d88a02c0c8b057979a3b8444fc19ceb3803bed1d5014a5266.zip",
         },
         "Description": "src/provider/credentials-handler.lambda.ts",
         "Environment": Object {


### PR DESCRIPTION

## Description of Changes

This PR introduces the ability to specify custom key names when storing the AWS SES SMTP server username and password in AWS Secrets Manager. Previously, the library defaulted to using `Credentials.USERNAME` and `Credentials.PASSWORD` as the keys. With this update:

1. **New Properties**:
   - Added `userNameSecretKey` and `passwordSecretKey` properties to the `SesSmtpCredentialsProps` interface.
   - These allow users to define custom key names for storing the username and password in Secrets Manager.

2. **Handler Changes**:
   - Updated the `credentials-handler.lambda.ts` to utilize the custom key names if provided.
   - Fallback to the default keys (`Credentials.USERNAME` and `Credentials.PASSWORD`) when the custom keys are not specified.

3. **Documentation**:
   - Updated the API documentation to reflect these changes.

## Why These Changes?

These enhancements provide greater flexibility when integrating the library into projects with specific naming conventions or requirements for secret storage (specifically the .Net NuGet library I am using to read AWS secrets into configuration). This reduces potential conflicts and aligns with best practices for customizability.

## Breaking Changes

_No breaking changes._ The library retains its default behavior if the new properties are not specified.

## Testing

- Verified that the handler correctly uses custom key names when specified.
- Ensured fallback behavior works seamlessly when the new properties are omitted.

_(Please note: This is my first ever PR :) While I had help from AI with this PR template, the code itself is definitely not AI generated! I also would be happy to implement the "update" functionality in the custom resource handler after this PR is complete. Thanks, CI)_

