### PR TITLE
fix: Migrate deprecated logRetention config to logGroup

### DIFF
--- a/src/provider/credentials-provider.ts
+++ b/src/provider/credentials-provider.ts
@@ -1,6 +1,6 @@
 import { Duration, Lazy, Stack } from "aws-cdk-lib";
 import { IUser, PolicyStatement } from "aws-cdk-lib/aws-iam";
-import { RetentionDays } from "aws-cdk-lib/aws-logs";
+import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
 import { ISecret } from "aws-cdk-lib/aws-secretsmanager";
 import { Provider } from "aws-cdk-lib/custom-resources";
 import { Construct } from "constructs";
@@ -48,12 +48,16 @@ export class CredentialsProvider extends Construct {
           actions: ["secretsmanager:PutSecretValue"],
         }),
       ],
-      logRetention: RetentionDays.ONE_MONTH,
+      logGroup: new LogGroup(this, "ses-smtp-credentials-handler-logs", {
+        retention: RetentionDays.ONE_MONTH,
+      }),
     });
 
     const provider = new Provider(this, "ses-smtp-credentials-provider", {
       onEventHandler: onEvent,
-      logRetention: RetentionDays.ONE_DAY, // default is INFINITE
+      logGroup: new LogGroup(this, "ses-smtp-credentials-provider-logs", {
+        retention: RetentionDays.ONE_DAY, // default is INFINITE
+      }),
     });
 
     this.serviceToken = provider.serviceToken;

--- a/test/__snapshots__/integ.default.test.ts.snap
+++ b/test/__snapshots__/integ.default.test.ts.snap
@@ -197,93 +197,6 @@ Object {
       "Type": "AWS::SecretsManager::Secret",
       "UpdateReplacePolicy": "Delete",
     },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": Object {
-      "DependsOn": Array [
-        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
-        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-      ],
-      "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "2819175352ad1ce0dae768e83fc328fb70fb5f10b4a8ff0ccbcb791f02b0716d.zip",
-        },
-        "Handler": "index.handler",
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-            "Arn",
-          ],
-        },
-        "Runtime": Object {
-          "Fn::FindInMap": Array [
-            "LatestNodeRuntimeMap",
-            Object {
-              "Ref": "AWS::Region",
-            },
-            "value",
-          ],
-        },
-        "Timeout": 900,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "logs:PutRetentionPolicy",
-                "logs:DeleteRetentionPolicy",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
-        "Roles": Array [
-          Object {
-            "Ref": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
     "User00B015A1": Object {
       "Properties": Object {
         "UserName": "SesTestUser",
@@ -309,6 +222,11 @@ Object {
           },
         },
         "Handler": "index.handler",
+        "LoggingConfig": Object {
+          "LogGroup": Object {
+            "Ref": "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandlerlogs3785D3A8",
+          },
+        },
         "Role": Object {
           "Fn::GetAtt": Array [
             "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandlerServiceRole18BEBF78",
@@ -319,29 +237,6 @@ Object {
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",
-    },
-    "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandlerLogRetention5C8B4A91": Object {
-      "Properties": Object {
-        "LogGroupName": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "/aws/lambda/",
-              Object {
-                "Ref": "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandler320CA55D",
-              },
-            ],
-          ],
-        },
-        "RetentionInDays": 30,
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "Custom::LogRetention",
     },
     "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandlerServiceRole18BEBF78": Object {
       "Properties": Object {
@@ -414,6 +309,14 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
+    "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandlerlogs3785D3A8": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "RetentionInDays": 30,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
     "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEvent1376F76C": Object {
       "DependsOn": Array [
         "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEventServiceRoleDefaultPolicyB231CF26",
@@ -438,6 +341,11 @@ Object {
           },
         },
         "Handler": "framework.onEvent",
+        "LoggingConfig": Object {
+          "LogGroup": Object {
+            "Ref": "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderlogsF298A30B",
+          },
+        },
         "Role": Object {
           "Fn::GetAtt": Array [
             "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEventServiceRoleFE45B538",
@@ -456,29 +364,6 @@ Object {
         "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",
-    },
-    "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEventLogRetentionCD61E4D7": Object {
-      "Properties": Object {
-        "LogGroupName": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "/aws/lambda/",
-              Object {
-                "Ref": "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEvent1376F76C",
-              },
-            ],
-          ],
-        },
-        "RetentionInDays": 1,
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "Custom::LogRetention",
     },
     "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEventServiceRoleDefaultPolicyB231CF26": Object {
       "Properties": Object {
@@ -552,6 +437,14 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderlogsF298A30B": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "RetentionInDays": 1,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
     },
   },
   "Rules": Object {

--- a/test/provider/__snapshots__/credentials-provider.test.ts.snap
+++ b/test/provider/__snapshots__/credentials-provider.test.ts.snap
@@ -134,93 +134,6 @@ Object {
     },
   },
   "Resources": Object {
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": Object {
-      "DependsOn": Array [
-        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
-        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-      ],
-      "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "2819175352ad1ce0dae768e83fc328fb70fb5f10b4a8ff0ccbcb791f02b0716d.zip",
-        },
-        "Handler": "index.handler",
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-            "Arn",
-          ],
-        },
-        "Runtime": Object {
-          "Fn::FindInMap": Array [
-            "LatestNodeRuntimeMap",
-            Object {
-              "Ref": "AWS::Region",
-            },
-            "value",
-          ],
-        },
-        "Timeout": 900,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "logs:PutRetentionPolicy",
-                "logs:DeleteRetentionPolicy",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
-        "Roles": Array [
-          Object {
-            "Ref": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
     "SecretA720EF05": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
@@ -251,6 +164,11 @@ Object {
           },
         },
         "Handler": "index.handler",
+        "LoggingConfig": Object {
+          "LogGroup": Object {
+            "Ref": "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandlerlogs3785D3A8",
+          },
+        },
         "Role": Object {
           "Fn::GetAtt": Array [
             "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandlerServiceRole18BEBF78",
@@ -261,29 +179,6 @@ Object {
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",
-    },
-    "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandlerLogRetention5C8B4A91": Object {
-      "Properties": Object {
-        "LogGroupName": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "/aws/lambda/",
-              Object {
-                "Ref": "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandler320CA55D",
-              },
-            ],
-          ],
-        },
-        "RetentionInDays": 30,
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "Custom::LogRetention",
     },
     "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandlerServiceRole18BEBF78": Object {
       "Properties": Object {
@@ -356,6 +251,14 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
+    "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialshandlerlogs3785D3A8": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "RetentionInDays": 30,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
     "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEvent1376F76C": Object {
       "DependsOn": Array [
         "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEventServiceRoleDefaultPolicyB231CF26",
@@ -380,6 +283,11 @@ Object {
           },
         },
         "Handler": "framework.onEvent",
+        "LoggingConfig": Object {
+          "LogGroup": Object {
+            "Ref": "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderlogsF298A30B",
+          },
+        },
         "Role": Object {
           "Fn::GetAtt": Array [
             "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEventServiceRoleFE45B538",
@@ -398,29 +306,6 @@ Object {
         "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",
-    },
-    "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEventLogRetentionCD61E4D7": Object {
-      "Properties": Object {
-        "LogGroupName": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "/aws/lambda/",
-              Object {
-                "Ref": "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEvent1376F76C",
-              },
-            ],
-          ],
-        },
-        "RetentionInDays": 1,
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "Custom::LogRetention",
     },
     "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderframeworkonEventServiceRoleDefaultPolicyB231CF26": Object {
       "Properties": Object {
@@ -494,6 +379,14 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "cdksessmtpcredentialsCredentialsProvidersessmtpcredentialsproviderlogsF298A30B": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "RetentionInDays": 1,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
     },
   },
   "Rules": Object {


### PR DESCRIPTION
Recent versions of CDK have deprecated the `logRetention` configuration in `lambda.Function`, in favor of an explicit `logGroup` configuration.

The `logRetention` in `custom-resources.Provider` is not yet deprecated, but is still documented as a 'legacy API', so migrate it too.